### PR TITLE
Get linting running

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,4 @@
 {
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
-	"ignorePatterns": ["**/vendor/**"],
-	"parserOptions": { "requireConfigFile" : false }
+	"ignorePatterns": ["**/vendor/**"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
-	"ignorePatterns": ["**/vendor/**"]
+	"ignorePatterns": ["**/vendor/**"],
+	"parserOptions": { "requireConfigFile" : false }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,0 @@
-{
-	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
-	"ignorePatterns": ["**/vendor/**"]
-}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+
+module.exports = {
+	extends: 'plugin:@wordpress/eslint-plugin/recommended-with-formatting',
+
+	root: true,
+
+	parserOptions: {
+		requireConfigFile: false,
+		babelOptions: {
+			presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
+		},
+	},
+
+	ignorePatterns: [ '*.min.js' ],
+};

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12
-    - name: npm install
+    - name: Install dependencies
       run: npm install
-    - name: eslint
-      uses: icrawl/action-eslint@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run JS linting
+      run: wp-scripts lint-js
+    - name: Run CSS linting
+      run: wp-scripts lint-css
   phpcs:
     name: WPCS
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Install dependencies
       run: npm install
     - name: Run JS linting
-      run: wp-scripts lint-js
+      run: npm run lint:js
     - name: Run CSS linting
-      run: wp-scripts lint-css
+      run: npm run lint:css
   phpcs:
     name: WPCS
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 			},
 			"devDependencies": {
 				"@wordpress/env": "^4.1.2",
+				"@wordpress/eslint-plugin": "^9.3.0",
 				"@wordpress/scripts": "^19.0.0"
 			}
 		},
@@ -79,6 +80,24 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/eslint-parser": {
+			"version": "7.16.3",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+			"integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+			"dev": true,
+			"dependencies": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.11.0",
+				"eslint": "^7.5.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@babel/generator": {
@@ -4674,18 +4693,18 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-9.2.0.tgz",
-			"integrity": "sha512-x0vI4EWeG20TyewXdiyUhGSJRqXR8vw47WZjzdmL8iuitDCoyWkKe73wtEs/mWLDrSNms8S0bTnp0dK6UAMXJw==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-9.3.0.tgz",
+			"integrity": "sha512-9F7B60gHAjiTIi9vBw5ZoH0MZW3UnmbuKols4kWpJVdgsvG4X1Wj6XXTLmQKrzh/Em7mD1CCIbCSyWknEzIOLw==",
 			"dev": true,
 			"dependencies": {
+				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^4.31.0",
 				"@typescript-eslint/parser": "^4.31.0",
 				"@wordpress/prettier-config": "^1.1.1",
-				"babel-eslint": "^10.1.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^7.1.0",
-				"eslint-plugin-import": "^2.23.4",
+				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^24.1.3",
 				"eslint-plugin-jsdoc": "^36.0.8",
 				"eslint-plugin-jsx-a11y": "^6.4.1",
@@ -5702,36 +5721,6 @@
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
 			"integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
 			"dev": true
-		},
-		"node_modules/babel-eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-			"deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"peerDependencies": {
-				"eslint": ">= 4.12.1"
-			}
-		},
-		"node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/babel-jest": {
 			"version": "26.6.3",
@@ -23005,6 +22994,17 @@
 				"source-map": "^0.5.0"
 			}
 		},
+		"@babel/eslint-parser": {
+			"version": "7.16.3",
+			"resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+			"integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+			"dev": true,
+			"requires": {
+				"eslint-scope": "^5.1.1",
+				"eslint-visitor-keys": "^2.1.0",
+				"semver": "^6.3.0"
+			}
+		},
 		"@babel/generator": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
@@ -26456,18 +26456,18 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-9.2.0.tgz",
-			"integrity": "sha512-x0vI4EWeG20TyewXdiyUhGSJRqXR8vw47WZjzdmL8iuitDCoyWkKe73wtEs/mWLDrSNms8S0bTnp0dK6UAMXJw==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-9.3.0.tgz",
+			"integrity": "sha512-9F7B60gHAjiTIi9vBw5ZoH0MZW3UnmbuKols4kWpJVdgsvG4X1Wj6XXTLmQKrzh/Em7mD1CCIbCSyWknEzIOLw==",
 			"dev": true,
 			"requires": {
+				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^4.31.0",
 				"@typescript-eslint/parser": "^4.31.0",
 				"@wordpress/prettier-config": "^1.1.1",
-				"babel-eslint": "^10.1.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^7.1.0",
-				"eslint-plugin-import": "^2.23.4",
+				"eslint-plugin-import": "^2.25.2",
 				"eslint-plugin-jest": "^24.1.3",
 				"eslint-plugin-jsdoc": "^36.0.8",
 				"eslint-plugin-jsx-a11y": "^6.4.1",
@@ -27226,28 +27226,6 @@
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
 			"integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
 			"dev": true
-		},
-		"babel-eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"resolve": "^1.12.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-					"dev": true
-				}
-			}
 		},
 		"babel-jest": {
 			"version": "26.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,7 @@
 			},
 			"devDependencies": {
 				"@wordpress/env": "^4.1.2",
-				"@wordpress/eslint-plugin": "^9.3.0",
-				"@wordpress/scripts": "^19.0.0",
-				"prettier": "^2.4.1"
+				"@wordpress/scripts": "^19.2.2"
 			}
 		},
 		"node_modules/@assemblyscript/loader": {
@@ -1435,20 +1433,78 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-			"integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+			"version": "7.16.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+			"integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.16.0",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"babel-plugin-polyfill-corejs2": "^0.2.3",
-				"babel-plugin-polyfill-corejs3": "^0.3.0",
-				"babel-plugin-polyfill-regenerator": "^0.2.3",
+				"babel-plugin-polyfill-corejs2": "^0.3.0",
+				"babel-plugin-polyfill-corejs3": "^0.4.0",
+				"babel-plugin-polyfill-regenerator": "^0.3.0",
 				"semver": "^6.3.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+			"integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^7.13.0",
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/helper-plugin-utils": "^7.13.0",
+				"@babel/traverse": "^7.13.0",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2",
+				"semver": "^6.1.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs2": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+			"integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.13.11",
+				"@babel/helper-define-polyfill-provider": "^0.3.0",
+				"semver": "^6.1.1"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+			"integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.3.0",
+				"core-js-compat": "^3.18.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-regenerator": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+			"integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.3.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -4207,32 +4263,32 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "6.3.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.3.4.tgz",
-			"integrity": "sha512-J0Axceu8pT4I6gOc9YDIiANZ/CKHSPtVSYoULMcsBWme4FyYckLMujH5avX8JNooJ3UCrX/rwEn4oq7dllmcZA==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.4.1.tgz",
+			"integrity": "sha512-T0+dPOn0Hus/FSP043H3C2awjGNWLJcSahm7LhLqT5uUtgdg6QD9yf4jSr7G5mpLO/DXgz2ZnaYMUj+d1/gk9w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/core": "^7.13.10",
-				"@babel/plugin-transform-react-jsx": "^7.12.7",
-				"@babel/plugin-transform-runtime": "^7.13.10",
-				"@babel/preset-env": "^7.13.10",
-				"@babel/preset-typescript": "^7.13.0",
-				"@babel/runtime": "^7.13.10",
+				"@babel/core": "^7.16.0",
+				"@babel/plugin-transform-react-jsx": "^7.16.0",
+				"@babel/plugin-transform-runtime": "^7.16.0",
+				"@babel/preset-env": "^7.16.0",
+				"@babel/preset-typescript": "^7.16.0",
+				"@babel/runtime": "^7.16.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^3.1.0",
 				"@wordpress/browserslist-config": "^4.1.0",
-				"@wordpress/element": "^4.0.3",
+				"@wordpress/element": "^4.0.4",
 				"@wordpress/warning": "^2.2.2",
-				"browserslist": "^4.16.6",
-				"core-js": "^3.12.1"
+				"browserslist": "^4.17.6",
+				"core-js": "^3.19.1"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.2.tgz",
-			"integrity": "sha512-0eESCFwdITSsWR+goVaWe3LZ/7s+GprNwANKF+1xm8gMxlHQks5gYDMvNdh0Q1yTHlK/vtg1VC7Bj1gydqmlxw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.4.tgz",
+			"integrity": "sha512-qXiIhWLdTHWxBWawcqigJUUMeb2jkn9ElUEUC/Cn3DK2i62jiUWXOLp6tFIaf5eQMNXsYqtp5r7n2F/OllngQA==",
 			"dev": true
 		},
 		"node_modules/@wordpress/blob": {
@@ -4841,12 +4897,12 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.1.0.tgz",
-			"integrity": "sha512-MAbEfYUH+odlYYtPNKoKnWzSZKZjSc2r2kvFJ7FR920ZdteEgSAPIOvjyv4r4UbJy3ZuKemnXHuVtcTAKca5Tw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.1.1.tgz",
+			"integrity": "sha512-f/DwduxU6k53tULurpCox4TKzp877+IWTHRUxE91+FOXS+2OsnhUPKfMiMEex4nu81a54EArwekPVKxaq4swbA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
+				"@babel/runtime": "^7.16.0",
 				"jest-matcher-utils": "^26.6.2",
 				"lodash": "^4.17.21"
 			},
@@ -4858,13 +4914,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-7.1.2.tgz",
-			"integrity": "sha512-TzrGj+eBrOQJxMLNh+gh+ImfFaK3caHLu7U4xF8UCGh6N+OuOTz5W9YHG/lqOuxDLdFhVkiHTytM2uFylGGRsg==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-7.1.3.tgz",
+			"integrity": "sha512-rz9V/YRr3TjLdZJQu7DAZHo848PpZ4N5ThtP4Lujy1O/UtcvtKF0r34SZTNDlFQO/G1USZQX/WL6HRhgl57iHA==",
 			"dev": true,
 			"dependencies": {
 				"@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
-				"@wordpress/jest-console": "^4.1.0",
+				"@wordpress/jest-console": "^4.1.1",
 				"babel-jest": "^26.6.3",
 				"enzyme": "^3.11.0",
 				"enzyme-to-json": "^3.4.4"
@@ -4933,12 +4989,12 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.3.tgz",
-			"integrity": "sha512-l7JDUDVnS0me3TjAzEEWO+OVumw2YHfEFhgwBCiLsXRRXOui8h64GCiIT71aiLpX6NG8Sn0AgBzKEfTotZZyAw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.5.tgz",
+			"integrity": "sha512-R+UKnjSJivvVEZ8rhGrXxsj/BlVeNO2FRXq3IxEOPv5ZRfAS0g8k8EO3xsCIV1RfnozvAApkKEYRClDYXIt+vA==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^4.0.2",
+				"@wordpress/base-styles": "^4.0.4",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
@@ -5018,24 +5074,24 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "19.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.0.0.tgz",
-			"integrity": "sha512-nx+s6ygP9hByPyZU5x6o3+Wq7DIRjyK0t2g9aSf+O3e2R0VQnJ5Hzy06wmud9t4Q+FT6HEOCbQkIYL/whY9k7w==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.2.tgz",
+			"integrity": "sha512-cH1NVhBKScNHIHXc3Af7FBOdsZBrA72IJVcZwUx79/BJVEhPVG3B9Kn4xkXP9RtYCkWETQ+s/KodzolL9RuHmQ==",
 			"dev": true,
 			"dependencies": {
 				"@svgr/webpack": "^5.5.0",
-				"@wordpress/babel-preset-default": "^6.3.4",
+				"@wordpress/babel-preset-default": "^6.4.1",
 				"@wordpress/browserslist-config": "^4.1.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "^3.2.1",
-				"@wordpress/eslint-plugin": "^9.2.0",
-				"@wordpress/jest-preset-default": "^7.1.2",
+				"@wordpress/eslint-plugin": "^9.3.0",
+				"@wordpress/jest-preset-default": "^7.1.3",
 				"@wordpress/npm-package-json-lint-config": "^4.1.0",
-				"@wordpress/postcss-plugins-preset": "^3.2.3",
+				"@wordpress/postcss-plugins-preset": "^3.2.5",
 				"@wordpress/prettier-config": "^1.1.1",
 				"@wordpress/stylelint-config": "^19.1.0",
 				"babel-jest": "^26.6.3",
-				"babel-loader": "^8.2.2",
-				"browserslist": "^4.16.6",
+				"babel-loader": "^8.2.3",
+				"browserslist": "^4.17.6",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
@@ -7212,9 +7268,9 @@
 			"dev": true
 		},
 		"node_modules/core-js": {
-			"version": "3.19.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
-			"integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==",
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
+			"integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -10088,9 +10144,9 @@
 			}
 		},
 		"node_modules/fraction.js": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
-			"integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
+			"integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -11923,9 +11979,9 @@
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
-			"integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.1.tgz",
+			"integrity": "sha512-q1kvhAXWSsXfMjCdNHNPKZZv94OlspKnoGv+R9RGbnqOOQ0VbNfLFgQDVgi7hHenKsndGq3/o0OBdzDXthWcNw==",
 			"dev": true,
 			"dependencies": {
 				"html-escaper": "^2.0.0",
@@ -12187,6 +12243,259 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+			"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+			"dev": true,
+			"dependencies": {
+				"@jest/core": "^26.6.3",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"import-local": "^3.0.2",
+				"is-ci": "^2.0.0",
+				"jest-config": "^26.6.3",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
+				"prompts": "^2.0.1",
+				"yargs": "^15.4.1"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": ">= 10.14.2"
+			}
+		},
+		"node_modules/jest-cli/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-cli/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-cli/node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/jest-cli/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-cli/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/jest-cli/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/jest-cli/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-cli/node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/jest-config": {
@@ -13945,259 +14254,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest/node_modules/cliui": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^6.2.0"
-			}
-		},
-		"node_modules/jest/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/jest/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/jest/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"node_modules/jest/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/jest-cli": {
-			"version": "26.6.3",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
-			"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-			"dev": true,
-			"dependencies": {
-				"@jest/core": "^26.6.3",
-				"@jest/test-result": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.4",
-				"import-local": "^3.0.2",
-				"is-ci": "^2.0.0",
-				"jest-config": "^26.6.3",
-				"jest-util": "^26.6.2",
-				"jest-validate": "^26.6.2",
-				"prompts": "^2.0.1",
-				"yargs": "^15.4.1"
-			},
-			"bin": {
-				"jest": "bin/jest.js"
-			},
-			"engines": {
-				"node": ">= 10.14.2"
-			}
-		},
-		"node_modules/jest/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/yargs": {
-			"version": "15.4.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-			"dev": true,
-			"dependencies": {
-				"cliui": "^6.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^4.1.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^4.2.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest/node_modules/yargs-parser": {
-			"version": "18.1.3",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/joi": {
@@ -17803,6 +17859,7 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
 			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -23927,17 +23984,65 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.0.tgz",
-			"integrity": "sha512-zlPf1/XFn5+vWdve3AAhf+Sxl+MVa5VlwTwWgnLx23u4GlatSRQJ3Eoo9vllf0a9il3woQsT4SK+5Z7c06h8ag==",
+			"version": "7.16.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+			"integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.16.0",
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"babel-plugin-polyfill-corejs2": "^0.2.3",
-				"babel-plugin-polyfill-corejs3": "^0.3.0",
-				"babel-plugin-polyfill-regenerator": "^0.2.3",
+				"babel-plugin-polyfill-corejs2": "^0.3.0",
+				"babel-plugin-polyfill-corejs3": "^0.4.0",
+				"babel-plugin-polyfill-regenerator": "^0.3.0",
 				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+					"integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-compilation-targets": "^7.13.0",
+						"@babel/helper-module-imports": "^7.12.13",
+						"@babel/helper-plugin-utils": "^7.13.0",
+						"@babel/traverse": "^7.13.0",
+						"debug": "^4.1.1",
+						"lodash.debounce": "^4.0.8",
+						"resolve": "^1.14.2",
+						"semver": "^6.1.2"
+					}
+				},
+				"babel-plugin-polyfill-corejs2": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+					"integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.13.11",
+						"@babel/helper-define-polyfill-provider": "^0.3.0",
+						"semver": "^6.1.1"
+					}
+				},
+				"babel-plugin-polyfill-corejs3": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+					"integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.3.0",
+						"core-js-compat": "^3.18.0"
+					}
+				},
+				"babel-plugin-polyfill-regenerator": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+					"integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-define-polyfill-provider": "^0.3.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -26092,29 +26197,29 @@
 			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "6.3.4",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.3.4.tgz",
-			"integrity": "sha512-J0Axceu8pT4I6gOc9YDIiANZ/CKHSPtVSYoULMcsBWme4FyYckLMujH5avX8JNooJ3UCrX/rwEn4oq7dllmcZA==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-6.4.1.tgz",
+			"integrity": "sha512-T0+dPOn0Hus/FSP043H3C2awjGNWLJcSahm7LhLqT5uUtgdg6QD9yf4jSr7G5mpLO/DXgz2ZnaYMUj+d1/gk9w==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.13.10",
-				"@babel/plugin-transform-react-jsx": "^7.12.7",
-				"@babel/plugin-transform-runtime": "^7.13.10",
-				"@babel/preset-env": "^7.13.10",
-				"@babel/preset-typescript": "^7.13.0",
-				"@babel/runtime": "^7.13.10",
+				"@babel/core": "^7.16.0",
+				"@babel/plugin-transform-react-jsx": "^7.16.0",
+				"@babel/plugin-transform-runtime": "^7.16.0",
+				"@babel/preset-env": "^7.16.0",
+				"@babel/preset-typescript": "^7.16.0",
+				"@babel/runtime": "^7.16.0",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^3.1.0",
 				"@wordpress/browserslist-config": "^4.1.0",
-				"@wordpress/element": "^4.0.3",
+				"@wordpress/element": "^4.0.4",
 				"@wordpress/warning": "^2.2.2",
-				"browserslist": "^4.16.6",
-				"core-js": "^3.12.1"
+				"browserslist": "^4.17.6",
+				"core-js": "^3.19.1"
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.2.tgz",
-			"integrity": "sha512-0eESCFwdITSsWR+goVaWe3LZ/7s+GprNwANKF+1xm8gMxlHQks5gYDMvNdh0Q1yTHlK/vtg1VC7Bj1gydqmlxw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.0.4.tgz",
+			"integrity": "sha512-qXiIhWLdTHWxBWawcqigJUUMeb2jkn9ElUEUC/Cn3DK2i62jiUWXOLp6tFIaf5eQMNXsYqtp5r7n2F/OllngQA==",
 			"dev": true
 		},
 		"@wordpress/blob": {
@@ -26590,24 +26695,24 @@
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.1.0.tgz",
-			"integrity": "sha512-MAbEfYUH+odlYYtPNKoKnWzSZKZjSc2r2kvFJ7FR920ZdteEgSAPIOvjyv4r4UbJy3ZuKemnXHuVtcTAKca5Tw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-4.1.1.tgz",
+			"integrity": "sha512-f/DwduxU6k53tULurpCox4TKzp877+IWTHRUxE91+FOXS+2OsnhUPKfMiMEex4nu81a54EArwekPVKxaq4swbA==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.13.10",
+				"@babel/runtime": "^7.16.0",
 				"jest-matcher-utils": "^26.6.2",
 				"lodash": "^4.17.21"
 			}
 		},
 		"@wordpress/jest-preset-default": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-7.1.2.tgz",
-			"integrity": "sha512-TzrGj+eBrOQJxMLNh+gh+ImfFaK3caHLu7U4xF8UCGh6N+OuOTz5W9YHG/lqOuxDLdFhVkiHTytM2uFylGGRsg==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-7.1.3.tgz",
+			"integrity": "sha512-rz9V/YRr3TjLdZJQu7DAZHo848PpZ4N5ThtP4Lujy1O/UtcvtKF0r34SZTNDlFQO/G1USZQX/WL6HRhgl57iHA==",
 			"dev": true,
 			"requires": {
 				"@wojtekmaj/enzyme-adapter-react-17": "^0.6.1",
-				"@wordpress/jest-console": "^4.1.0",
+				"@wordpress/jest-console": "^4.1.1",
 				"babel-jest": "^26.6.3",
 				"enzyme": "^3.11.0",
 				"enzyme-to-json": "^3.4.4"
@@ -26656,12 +26761,12 @@
 			"requires": {}
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.3.tgz",
-			"integrity": "sha512-l7JDUDVnS0me3TjAzEEWO+OVumw2YHfEFhgwBCiLsXRRXOui8h64GCiIT71aiLpX6NG8Sn0AgBzKEfTotZZyAw==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-3.2.5.tgz",
+			"integrity": "sha512-R+UKnjSJivvVEZ8rhGrXxsj/BlVeNO2FRXq3IxEOPv5ZRfAS0g8k8EO3xsCIV1RfnozvAApkKEYRClDYXIt+vA==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^4.0.2",
+				"@wordpress/base-styles": "^4.0.4",
 				"autoprefixer": "^10.2.5"
 			}
 		},
@@ -26723,24 +26828,24 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "19.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.0.0.tgz",
-			"integrity": "sha512-nx+s6ygP9hByPyZU5x6o3+Wq7DIRjyK0t2g9aSf+O3e2R0VQnJ5Hzy06wmud9t4Q+FT6HEOCbQkIYL/whY9k7w==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.2.2.tgz",
+			"integrity": "sha512-cH1NVhBKScNHIHXc3Af7FBOdsZBrA72IJVcZwUx79/BJVEhPVG3B9Kn4xkXP9RtYCkWETQ+s/KodzolL9RuHmQ==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.5.0",
-				"@wordpress/babel-preset-default": "^6.3.4",
+				"@wordpress/babel-preset-default": "^6.4.1",
 				"@wordpress/browserslist-config": "^4.1.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "^3.2.1",
-				"@wordpress/eslint-plugin": "^9.2.0",
-				"@wordpress/jest-preset-default": "^7.1.2",
+				"@wordpress/eslint-plugin": "^9.3.0",
+				"@wordpress/jest-preset-default": "^7.1.3",
 				"@wordpress/npm-package-json-lint-config": "^4.1.0",
-				"@wordpress/postcss-plugins-preset": "^3.2.3",
+				"@wordpress/postcss-plugins-preset": "^3.2.5",
 				"@wordpress/prettier-config": "^1.1.1",
 				"@wordpress/stylelint-config": "^19.1.0",
 				"babel-jest": "^26.6.3",
-				"babel-loader": "^8.2.2",
-				"browserslist": "^4.16.6",
+				"babel-loader": "^8.2.3",
+				"browserslist": "^4.17.6",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
 				"clean-webpack-plugin": "^3.0.0",
@@ -28427,9 +28532,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.19.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
-			"integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==",
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
+			"integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
 			"dev": true
 		},
 		"core-js-compat": {
@@ -30636,9 +30741,9 @@
 			}
 		},
 		"fraction.js": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
-			"integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
+			"integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
 			"dev": true
 		},
 		"fragment-cache": {
@@ -31984,9 +32089,9 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
-			"integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.1.tgz",
+			"integrity": "sha512-q1kvhAXWSsXfMjCdNHNPKZZv94OlspKnoGv+R9RGbnqOOQ0VbNfLFgQDVgi7hHenKsndGq3/o0OBdzDXthWcNw==",
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0",
@@ -32002,201 +32107,6 @@
 				"@jest/core": "^26.6.3",
 				"import-local": "^3.0.2",
 				"jest-cli": "^26.6.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"jest-cli": {
-					"version": "26.6.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
-					"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-					"dev": true,
-					"requires": {
-						"@jest/core": "^26.6.3",
-						"@jest/test-result": "^26.6.2",
-						"@jest/types": "^26.6.2",
-						"chalk": "^4.0.0",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.2.4",
-						"import-local": "^3.0.2",
-						"is-ci": "^2.0.0",
-						"jest-config": "^26.6.3",
-						"jest-util": "^26.6.2",
-						"jest-validate": "^26.6.2",
-						"prompts": "^2.0.1",
-						"yargs": "^15.4.1"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.1"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.4.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-					"dev": true,
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.2"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
 			}
 		},
 		"jest-changed-files": {
@@ -32370,6 +32280,201 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"jest-cli": {
+			"version": "26.6.3",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+			"integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+			"dev": true,
+			"requires": {
+				"@jest/core": "^26.6.3",
+				"@jest/test-result": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"chalk": "^4.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"import-local": "^3.0.2",
+				"is-ci": "^2.0.0",
+				"jest-config": "^26.6.3",
+				"jest-util": "^26.6.2",
+				"jest-validate": "^26.6.2",
+				"prompts": "^2.0.1",
+				"yargs": "^15.4.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -36400,7 +36505,8 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
 			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
 			"devDependencies": {
 				"@wordpress/env": "^4.1.2",
 				"@wordpress/eslint-plugin": "^9.3.0",
-				"@wordpress/scripts": "^19.0.0"
+				"@wordpress/scripts": "^19.0.0",
+				"prettier": "^2.4.1"
 			}
 		},
 		"node_modules/@assemblyscript/loader": {
@@ -4760,6 +4761,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@wordpress/eslint-plugin/node_modules/prettier": {
+			"name": "wp-prettier",
+			"version": "2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/@wordpress/hooks": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.2.tgz",
@@ -5125,6 +5139,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/@wordpress/scripts/node_modules/prettier": {
+			"name": "wp-prettier",
+			"version": "2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/supports-color": {
@@ -17772,11 +17799,16 @@
 			}
 		},
 		"node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-			"dev": true
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
 		},
 		"node_modules/prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -26500,6 +26532,12 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+					"dev": true
 				}
 			}
 		},
@@ -26781,6 +26819,12 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@2.2.1-beta-1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 					"dev": true
 				},
 				"supports-color": {
@@ -36353,9 +36397,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+			"integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
 		"wp-env": "wp-env",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
-		"lint": "./node_modules/eslint/bin/eslint.js --ext js,jsx,ts,tsx src/",
 		"start": "wp-scripts start",
 		"packages-update": "wp-scripts packages-update"
 	},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/10up/winamp-block"
 	},
 	"scripts": {
-		"build": "wp-scripts build ",
+		"build": "wp-scripts build",
 		"format": "wp-scripts format",
 		"wp-env": "wp-env",
 		"lint:css": "wp-scripts lint-style",
@@ -40,8 +40,6 @@
 	},
 	"devDependencies": {
 		"@wordpress/env": "^4.1.2",
-		"@wordpress/eslint-plugin": "^9.3.0",
-		"@wordpress/scripts": "^19.0.0",
-		"prettier": "^2.4.1"
+		"@wordpress/scripts": "^19.2.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"wp-env": "wp-env",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
+		"lint": "./node_modules/eslint/bin/eslint.js --ext js,jsx,ts,tsx src/",
 		"start": "wp-scripts start",
 		"packages-update": "wp-scripts packages-update"
 	},
@@ -41,6 +42,7 @@
 	"devDependencies": {
 		"@wordpress/env": "^4.1.2",
 		"@wordpress/eslint-plugin": "^9.3.0",
-		"@wordpress/scripts": "^19.0.0"
+		"@wordpress/scripts": "^19.0.0",
+		"prettier": "^2.4.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	},
 	"devDependencies": {
 		"@wordpress/env": "^4.1.2",
+		"@wordpress/eslint-plugin": "^9.3.0",
 		"@wordpress/scripts": "^19.0.0"
 	}
 }

--- a/src/edit.js
+++ b/src/edit.js
@@ -31,9 +31,9 @@ const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'ADD MEDIA', 'winamp-block' )
 	: __(
-			'To view the Winamp player, drag audio files, upload new ones, or select files from your library.',
-			'winamp-block'
-	  );
+		'To view the Winamp player, drag audio files, upload new ones, or select files from your library.',
+		'winamp-block'
+	);
 
 /**
  * The edit function describes the structure of your block in the context of the
@@ -105,14 +105,14 @@ function Edit( props ) {
 
 		const audioArray = newFileUploads
 			? Array.from( selectedAudio ).map( ( file ) => {
-					if ( ! file.url ) {
-						return {
-							url: createBlobURL( file ),
-						};
-					}
+				if ( ! file.url ) {
+					return {
+						url: createBlobURL( file ),
+					};
+				}
 
-					return file;
-			  } )
+				return file;
+			} )
 			: selectedAudio;
 
 		const processedAudio = audioArray
@@ -139,10 +139,10 @@ function Edit( props ) {
 
 		const existingAudioBlocks = ! newFileUploads
 			? innerBlockAudio.filter( ( block ) =>
-					processedAudio.find(
-						( img ) => img.id === block.attributes.id
-					)
-			  )
+				processedAudio.find(
+					( img ) => img.id === block.attributes.id
+				)
+			)
 			: innerBlockAudio;
 
 		const newAudioList = processedAudio.filter(


### PR DESCRIPTION
### Description of the Change

Ensure both JS and CSS linting runs in our GitHub Actions workflow. Instead of relying on the eslint action, switch to using the linting that `wp-scripts` provides. This required some config changes and a few fixes to linting issues that were found

