### PR TITLE
Bump WordPress "tested up to" version 6.4 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, dinhtungdu, fabiankaegy, dkotter, melchoyce, jeffpaul
 Tags:              winamp, webamp, mp3, music, audio, player, playlist, equalizer, block
 Requires at least: 6.1
-Tested up to:      6.3
+Tested up to:      6.4
 Stable tag:        1.3.1
 Requires PHP:      7.4
 License:           GPLv2 or later


### PR DESCRIPTION
Ports the change in #114 to `trunk` in hopes of triggering the WP.org readme update action.