### PR TITLE
Enhancements

### DIFF
--- a/block.json
+++ b/block.json
@@ -37,7 +37,7 @@
 		},
 		"preview": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		}
 	},
 	"example": {

--- a/src/audio.js
+++ b/src/audio.js
@@ -6,15 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { BlockControls } from '@wordpress/block-editor';
 
 // since we want to support both 5.6+ & 5.9 we need to conditional import it this way
 const useInnerBlocksProps = wp.blockEditor.useInnerBlocksProps
 	? wp.blockEditor.useInnerBlocksProps
 	: wp.blockEditor.__experimentalUseInnerBlocksProps;
 
-import { __ } from '@wordpress/i18n';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
 
@@ -26,22 +23,12 @@ import WebAmp from './webamp';
 const allowedBlocks = [ 'core/audio' ];
 
 export const Audio = ( props ) => {
-	const { audio, currentSkin, mediaPlaceholder, blockProps } = props;
-
-	const [ isPreview, setIsPreview ] = useState();
+	const { audio, currentSkin, mediaPlaceholder, blockProps, preview: isPreview } = props;
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		allowedBlocks,
 		renderAppender: false,
 	} );
-
-	function switchToPreview() {
-		setIsPreview( true );
-	}
-
-	function switchToList() {
-		setIsPreview( false );
-	}
 
 	return (
 		<figure
@@ -51,25 +38,6 @@ export const Audio = ( props ) => {
 				'blocks-audio-list'
 			) }
 		>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						className="components-tab-button"
-						isPressed={ ! isPreview }
-						onClick={ switchToList }
-					>
-						<span>{ __( 'Audio List', 'winamp-block' ) }</span>
-					</ToolbarButton>
-					<ToolbarButton
-						className="components-tab-button"
-						isPressed={ isPreview }
-						onClick={ switchToPreview }
-					>
-						<span>{ __( 'Preview Player', 'winamp-block' ) }</span>
-					</ToolbarButton>
-				</ToolbarGroup>
-			</BlockControls>
-
 			{ isPreview ? (
 				<WebAmp audio={ audio } currentSkin={ currentSkin } />
 			) : (

--- a/src/audio.js
+++ b/src/audio.js
@@ -12,7 +12,6 @@ const useInnerBlocksProps = wp.blockEditor.useInnerBlocksProps
 	? wp.blockEditor.useInnerBlocksProps
 	: wp.blockEditor.__experimentalUseInnerBlocksProps;
 
-import { useState } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
 
 /**

--- a/src/audio.js
+++ b/src/audio.js
@@ -38,7 +38,9 @@ export const Audio = ( props ) => {
 			) }
 		>
 			{ isPreview ? (
-				<WebAmp audio={ audio } currentSkin={ currentSkin } />
+				<div id="webamp-container">
+					<WebAmp audio={ audio } currentSkin={ currentSkin } preview={ isPreview } />
+				</div>
 			) : (
 				<>
 					{ children }

--- a/src/audio.js
+++ b/src/audio.js
@@ -6,13 +6,15 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-
+import { BlockControls } from '@wordpress/block-editor';
 // since we want to support both 5.6+ & 5.9 we need to conditional import it this way
 const useInnerBlocksProps = wp.blockEditor.useInnerBlocksProps
 	? wp.blockEditor.useInnerBlocksProps
 	: wp.blockEditor.__experimentalUseInnerBlocksProps;
 
 import { View } from '@wordpress/primitives';
+import { __ } from '@wordpress/i18n';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -22,7 +24,7 @@ import WebAmp from './webamp';
 const allowedBlocks = [ 'core/audio' ];
 
 export const Audio = ( props ) => {
-	const { audio, currentSkin, mediaPlaceholder, blockProps, preview: isPreview } = props;
+	const { audio, currentSkin, mediaPlaceholder, blockProps, preview: isPreview, setAttributes } = props;
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		allowedBlocks,
@@ -36,7 +38,31 @@ export const Audio = ( props ) => {
 				blockProps.className,
 				'blocks-audio-list'
 			) }
+
 		>
+			<BlockControls>
+				<ToolbarGroup>
+					{ isPreview ? (
+						<ToolbarButton
+							className="components-tab-button winamp-show-media"
+							onClick={ () => {
+								setAttributes( { preview: ! isPreview } );
+							} }
+						>
+							<span>{ __( 'Manage Media', 'winamp-block' ) }</span>
+						</ToolbarButton>
+					) : (
+						<ToolbarButton
+							className="components-tab-button winamp-show-preview"
+							onClick={ () => {
+								setAttributes( { preview: ! isPreview } );
+							} }
+						>
+							<span>{ __( 'Show Preview', 'winamp-block' ) }</span>
+						</ToolbarButton>
+					) }
+				</ToolbarGroup>
+			</BlockControls>
 			{ isPreview ? (
 				<div id="webamp-container">
 					<WebAmp audio={ audio } currentSkin={ currentSkin } preview={ isPreview } />

--- a/src/edit.js
+++ b/src/edit.js
@@ -282,6 +282,7 @@ function Edit( props ) {
 				mediaPlaceholder={ mediaPlaceholder }
 				blockProps={ blockProps }
 				preview={ preview }
+				setAttributes={ setAttributes }
 			/>
 		</>
 	);

--- a/src/edit.js
+++ b/src/edit.js
@@ -280,6 +280,11 @@ function Edit( props ) {
 						checked={ useCustomUrl }
 						onChange={ () => setUseCustomUrl( ! useCustomUrl ) }
 					/>
+					<ToggleControl
+						label={ __( 'Show Preview?', 'winamp-block' ) }
+						checked={ preview }
+						onChange={ () => setAttributes( { preview: ! preview } ) }
+					/>
 				</PanelBody>
 			</InspectorControls>
 			{ noticeUI }
@@ -288,6 +293,7 @@ function Edit( props ) {
 				currentSkin={ currentSkin }
 				mediaPlaceholder={ mediaPlaceholder }
 				blockProps={ blockProps }
+				preview={ preview }
 			/>
 		</>
 	);

--- a/src/edit.js
+++ b/src/edit.js
@@ -30,7 +30,6 @@ import { createBlobURL } from '@wordpress/blob';
  */
 import './editor.scss';
 import Audio from './audio';
-import previewImg from '../assets/default-player.jpg';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 const PLACEHOLDER_TEXT = Platform.isNative

--- a/src/edit.js
+++ b/src/edit.js
@@ -61,17 +61,6 @@ function Edit( props ) {
 	const { currentSkin, preview } = attributes;
 	const [ useCustomUrl, setUseCustomUrl ] = useState( false );
 
-	if ( preview && previewImg ) {
-		return (
-			<>
-				<img
-					src={ previewImg }
-					alt={ __( 'Winamp Player', 'winamp-block' ) }
-				/>
-			</>
-		);
-	}
-
 	const blockProps = useBlockProps(); // eslint-disable-line react-hooks/rules-of-hooks
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore ); // eslint-disable-line react-hooks/rules-of-hooks
 

--- a/src/webamp.js
+++ b/src/webamp.js
@@ -7,7 +7,7 @@ import Webamp from 'webamp';
 import milkdropOptions from './milkdrop';
 
 export const WebAmp = ( props ) => {
-	const { audio = [], currentSkin = '' } = props;
+	const { audio = [], currentSkin = '', preview = true } = props;
 	const divRef = useRef( null );
 	const [ webamp, setWebamp ] = useState( null );
 
@@ -40,16 +40,47 @@ export const WebAmp = ( props ) => {
 		const player = new Webamp( { ...options, ...milkdropOptions } );
 		setWebamp( player );
 		player.renderWhenReady( divRef.current ).then( () => {
-			const webAmpContainer = document.getElementById( 'webamp' );
+			const webAmp = document.getElementById( 'webamp' );
+
+			// Move the Webamp player markup into the block
+			// so that the block can be interacted with while the player is visible
+			const webampContainer = document.getElementById( 'webamp-container' );
+
+			if ( webampContainer && webAmp ) {
+				webampContainer.appendChild( webAmp );
+			}
+
+			// This is a hack to move the UI elements into the correct position. The
+			// Webamp library tries to center the player in the window, but we want it
+			// to be tucked neatly in the block.
+			const webAmpUI = document.querySelectorAll( '#webamp > div > div > div' );
+			const mapping = {
+				0: 'translate( 0px, 0px )',
+				1: 'translate( 0px, 232px )',
+				2: 'translate( 0px, 116px )',
+				3: 'translate( 275px, 0px )',
+			};
+
+			// make sure all the UI elements are available to manipulate
+			if ( webAmpUI.length === 4 ) {
+				webAmpUI.forEach( ( ui, i ) => {
+					ui.style.transform = mapping[ i ];
+				} );
+			}
 
 			// Add is loaded class after artifical delay to reduce page jank
-			if ( webAmpContainer ) {
-				webAmpContainer.classList.add( 'is-loaded' );
+			if ( webAmp ) {
+				webAmp.classList.add( 'is-loaded' );
 			}
 		} );
 
 		return () => {
-			player.dispose();
+			// Hide the player instaed of destroying it. This allows the player
+			// to persist between previews and playlist modification.
+			const webampContainer = document.getElementById( 'webamp' );
+			if ( webampContainer ) {
+				webampContainer.style.display = ! preview ? 'none' : 'block';
+			}
 		};
 	}, [ divRef.current ] );
 

--- a/src/webamp.js
+++ b/src/webamp.js
@@ -75,7 +75,7 @@ export const WebAmp = ( props ) => {
 		} );
 
 		return () => {
-			// Hide the player instaed of destroying it. This allows the player
+			// Hide the player instead of destroying it. This allows the player
 			// to persist between previews and playlist modification.
 			const webampContainer = document.getElementById( 'webamp' );
 			if ( webampContainer ) {

--- a/tests/cypress/config.js
+++ b/tests/cypress/config.js
@@ -3,6 +3,7 @@ const { loadConfig } = require( '@wordpress/env/lib/config' );
 const getCacheDirectory = require('@wordpress/env/lib/config/get-cache-directory');
 
 module.exports = defineConfig( {
+	chromeWebSecurity: false,
 	fixturesFolder: 'tests/cypress/fixtures',
 	screenshotsFolder: 'tests/cypress/screenshots',
 	videosFolder: 'tests/cypress/videos',

--- a/tests/cypress/e2e/block.test.js
+++ b/tests/cypress/e2e/block.test.js
@@ -38,9 +38,19 @@ describe( 'Admin can publish posts with winamp block', () => {
 		}).then( post => {
 			cy.visit( `/wp-admin/post.php?post=${post.id}&action=edit` );
 			// verify page contains new block
-			cy.get( '.wp-block-audio audio' )
+			cy.get( '.wp-block-tenup-winamp-block' );
+			// toggle to 'Manage Media' view
+			cy.get( '.components-tab-button.winamp-show-media').click();
+			// Confirm the audio file is present
+			cy.get('.wp-block-audio audio')				
 				.should( 'have.attr', 'src' )
 				.and( 'include', 'example' );
+			// toggle to 'Show Preview' view
+			cy.get( '.components-tab-button.winamp-show-preview').click();
+			// confirm webamp is showing
+			cy.get( '#webamp' )
+				.should( 'have.css', 'display', 'block' );
+
 		});
 	} );
 } );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

![Kapture 2024-02-07 at 18 13 00](https://github.com/10up/retro-winamp-block/assets/6152801/d84305da-109b-420d-95ab-c60ce8cfe657)



<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #119 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Add new winamp block
2. Select a media file
3. Confirm preview is shown
4. Confirm preview toggle is located in the block's inspector control and works properly
5. Confirm "Manage Media" block control is present when in preview mode
6. Confirm "Show Preview" block control is present when in manage media mode
7. Confirm preview setting persists after page update & reload
8. Cionfr

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Winamp skin preview setting to be on by default.
> Changed - Moved preview toggle to inspector controls from block controls.
> Changed - Moved webamp component to be nested inside the block, so that clicking that interacting the component also activates the block selection

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @psorensen 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
