### PR TITLE
Fix the WordPress.org plugin preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-	"landingPage": "\/wp-admin\/post.php?post=5&action=edit",
+	"landingPage": "\/wp-admin\/post.php?post=4&action=edit",
 	"preferredVersions": {
 		"php": "7.4",
 		"wp": "latest"
@@ -23,7 +23,7 @@
 			}
 		},
 		{
-			"step": "importFile",
+			"step": "importWxr",
 			"file": {
 				"resource": "url",
 				"url": "https:\/\/raw.githubusercontent.com\/10up\/retro-winamp-block\/d2ff63d1127713d9f2a11235a002f38f2927b0ca\/.wordpress-org\/blueprints\/demo-data.xml"


### PR DESCRIPTION
### Description of the Change

In #116 we added support for the WordPress.org plugin preview. As [noted](https://github.com/10up/retro-winamp-block/pull/116#issuecomment-2269929019), testing that now results in an error.

Digging in I found two issues:

1. We use a `importFile` step but that has been removed in favor of `importWxr`
2. The landing page we send people to uses the post ID of 5 but seems that now gets imported with a post ID of 4

Both of these issues have been fixed in this PR.

### How to test the Change

The WordPress Playground allows you to spin up a new environment directly through the URL, by going to `https://playground.wordpress.net/#` and pasting your JSON config after the `#`. In this case, the URL should be:

https://playground.wordpress.net/#{"$schema":"https://playground.wordpress.net/blueprint-schema.json","landingPage":"/wp-admin/post.php?post=4&action=edit","preferredVersions":{"php":"7.4","wp":"latest"},"phpExtensionBundles":["kitchen-sink"],"steps":[{"step":"login","username":"admin","password":"password"},{"step":"installPlugin","pluginZipFile":{"resource":"wordpress.org/plugins","slug":"retro-winamp-block"},"options":{"activate":true}},{"step":"importWxr","file":{"resource":"url","url":"https://raw.githubusercontent.com/10up/retro-winamp-block/d2ff63d1127713d9f2a11235a002f38f2927b0ca/.wordpress-org/blueprints/demo-data.xml"}}]}

Ensure that clicking that link loads a proper preview environment with the plugin installed and demo content loaded

### Changelog Entry

> Fixed - Ensure the WordPress.org plugin preview works as expected

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
