### PR TITLE
Bump Tested up to

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Do you miss the days of filling up your computer's harddrive with MP3 files, bur
 ## Requirements
 
 * PHP >=7.4
-* [WordPress](http://wordpress.org/) >=6.4
+* [WordPress](http://wordpress.org/) >=6.5
 
 ## Installation
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Retro Winamp Block ===
 Contributors:      10up, dinhtungdu, fabiankaegy, dkotter, melchoyce, jeffpaul
 Tags:              winamp, mp3, music, player, equalizer
-Tested up to:      6.6
+Tested up to:      6.7
 Stable tag:        1.3.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/retro-webamp-block.php
+++ b/retro-webamp-block.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://wordpress.org/plugins/retro-winamp-block/
  * Description:       A Winamp-styled audio block for all your retro music player needs.
  * Version:           1.3.2
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change

- I've tested the plugin on `6.7-RC1`, inserted the block and set an audio file in it, confirmed it played correctly.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/retro-winamp-block/issues/152

### How to test the Change
-  Update to 6.7 release candidate, confirm block works as expected

### Changelog Entry
> Changed - Bump WordPress "tested up to" version 6.7.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
