### PR TITLE
Update all actions we use in our workflows to pull from specific pinned commits

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -10,13 +10,14 @@ jobs:
   build:
     name: Build release zip
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         env:
           cache-name: cache-node-modules
         with:
@@ -24,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup node version and npm cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -37,4 +38,4 @@ jobs:
         run: npm run build
 
       - name: Generate ZIP file
-        uses: 10up/action-wordpress-plugin-build-zip@stable
+        uses: 10up/action-wordpress-plugin-build-zip@b9e621e1261ccf51592b6f3943e4dc4518fca0d1 # v1.0.2

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 7
           days-before-close: 7
@@ -33,4 +33,4 @@ jobs:
           close-issue-reason: 'not_planned'
           any-of-labels: 'reporter feedback'
           remove-stale-when-updated: true
-          
+

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - develop
+
 jobs:
   cypress:
     name: ${{ matrix.core.name }}
@@ -19,20 +20,27 @@ jobs:
           - {name: 'WP latest', version: 'latest'}
           - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Install dependencies
       run: npm install
+
     - name: Composer (optional)
       run: composer install
       continue-on-error: true
+
     - name: Build (optional)
       run: npm run build
       continue-on-error: true
+
     - name: Set the core version
       run: ./tests/bin/set-core-version.js ${{ matrix.core.version }}
+
     - name: Set up WP environment
       run: npm run env:start
+
     - name: Test
       run: npm run cypress:run

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3
         with:
           license-check: true
           vulnerability-check: false

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,15 +13,20 @@ jobs:
   eslint:
     name: eslint
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version-file: '.nvmrc'
+
     - name: Install dependencies
       run: npm install
+
     - name: Run JS linting
       run: npm run lint:js
+
     - name: Run CSS linting
       run: npm run lint:css

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: '7.4'
           tools: composer:v2

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -13,9 +13,11 @@ jobs:
   phpcs:
     name: WPCS
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: WPCS check
-        uses: 10up/wpcs-action@stable
+        uses: 10up/wpcs-action@4b2d47a70e3a0a9c08b40a4a90bc3ccbbdc12b3f # v1.7.0
         with:
           standard: 'WordPress'

--- a/.github/workflows/wordpress-plugin-asset-update.yml
+++ b/.github/workflows/wordpress-plugin-asset-update.yml
@@ -1,20 +1,25 @@
 name: Update asset/readme on WordPress.org
+
 on:
   push:
     branches:
     - trunk
+
 jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Build
       run: |
         npm install
         npm run build
+
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
+      uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # v2.2.0
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -1,28 +1,34 @@
 name: Deploy to WordPress.org
+
 on:
   release:
     types: [published]
+
 jobs:
   tag:
     name: New release
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Build
       run: |
         npm install
         npm run build
+
     - name: WordPress Plugin Deploy
       id: deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
       with:
         generate-zip: true
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
     - name: Upload release asset
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -1,4 +1,5 @@
 name: "WordPress version checker"
+
 on:
   push:
     branches:
@@ -18,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: WordPress version checker
-        uses: skaut/wordpress-version-checker@master
+        uses: skaut/wordpress-version-checker@9d247334f5b30202cb9c1f4aee74c52f37399f69 # v2.2.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of the Change

In order to help protect against compromised actions, instead of including actions based on their major version (like v4), this PR switches all the actions we use to pull based on the commit hash from the latest release.

While this does impact maintenance a bit going forward, it ensures that we we're always using actions that we (hopefully) trust and if an action gets compromised (which [happens](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/)) we don't have to worry that we're using a compromised action. This also goes along with what [GitHub suggests](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### How to test the Change

Ensure all our workflows still run as expected

### Changelog Entry

> Developer - Update all third-party actions our workflows rely on to use versions based on specific commit hashes.

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
