### PR TITLE
Fix blueprint

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "wordpress.org\/plugins",
 				"slug": "retro-winamp-block"
 			},

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -5,23 +5,11 @@
 		"php": "7.4",
 		"wp": "latest"
 	},
-	"phpExtensionBundles": ["kitchen-sink"],
+	"plugins": [
+		"retro-winamp-block"
+	],
+	"login": true,
 	"steps": [
-		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
-		{
-			"step": "installPlugin",
-			"pluginData": {
-				"resource": "wordpress.org\/plugins",
-				"slug": "retro-winamp-block"
-			},
-			"options": {
-				"activate": true
-			}
-		},
 		{
 			"step": "importWxr",
 			"file": {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
In trying to quickly triage a recent WPORG support forum post, I tried to leverage the Live Preview but came across an error there:

> [02-Jul-2025 18:18:41 UTC] JavaScript Warn: The "pluginZipFile" option of the "installPlugin" step is deprecated. Use "pluginData" instead.
[02-Jul-2025 18:18:41 UTC] JavaScript Warn: The "pluginZipFile" option of the "installPlugin" step is deprecated. Use "pluginData" instead.
[02-Jul-2025 18:19:15 UTC] JavaScript Error: The operation was aborted. 

This pull request updates the `.wordpress-org/blueprints/blueprint.json` file to rename a key in the JSON structure for clarity and consistency.

* [`.wordpress-org/blueprints/blueprint.json`](diffhunk://#diff-0c8e8cdc6acb984680b26ee496aafb533f79c7a7f37f1b4905e84dca0f625863L17-R17): Renamed the key `pluginZipFile` to `pluginData` in the `installPlugin` step to better reflect the data being referenced.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - WP.org Blueprint for Live Preview functionality.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
