### PR TITLE
Bump tested up to header to indicate WordPress 6.9 support.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Retro Winamp Block ===
 Contributors:      10up, dinhtungdu, fabiankaegy, dkotter, melchoyce, jeffpaul
 Tags:              winamp, mp3, music, player, equalizer
-Tested up to:      6.8
+Tested up to:      6.9
 Stable tag:        1.3.3
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change

Bump tested up to header to indicate WordPress 6.9 support.

Closes #177

### How to test the Change

N/A: See testing notes on the related issue.

### Changelog Entry
> Changed - Bump tested up to header to indicate WordPress 6.9 support.

### Credits
Props @peterwilsoncc 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
